### PR TITLE
yogisha/fix shop + responsiveness

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,14 +1,18 @@
-const FluidApiClient = async (url: string, options?: RequestInit) => {
-  const response = await fetch(
-    `${process.env.FLUID_BASE_URL}/api/company/v1/${url}`,
-    {
-      ...options,
-      headers: {
-        ...options?.headers,
-        Authorization: `Bearer ${process.env.FLUID_API_TOKEN}`,
-      },
-    }
-  );
+const FluidApiClient = async (
+  url: string,
+  isV1 = true,
+  options?: RequestInit
+) => {
+  const baseUrl = isV1
+    ? `${process.env.FLUID_BASE_URL}/api/company/v1/`
+    : `${process.env.FLUID_BASE_URL}/api/`;
+  const response = await fetch(`${baseUrl}${url}`, {
+    ...options,
+    headers: {
+      ...options?.headers,
+      Authorization: `Bearer ${process.env.FLUID_API_TOKEN}`,
+    },
+  });
 
   // instead of having to async get the body from every client call, we can just do it here
   return {

--- a/src/api/getCart.ts
+++ b/src/api/getCart.ts
@@ -1,0 +1,16 @@
+"use server";
+import { safeZodParse } from "@/api";
+import client from "@/api/client";
+import { Carts, cartSchema } from "@/types/cart";
+import { cookies } from "next/headers";
+
+async function getCart(): Promise<Carts> {
+  const cookiesList = cookies();
+  const cartToken = cookiesList.get("cartToken")?.value;
+
+  const { body } = await client(`carts/${cartToken}`, false);
+
+  return safeZodParse(body, cartSchema);
+}
+
+export default getCart;

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -3,6 +3,7 @@ import getCollection from "./getCollection";
 import getCollections from "./getCollections";
 import getProduct from "./getProduct";
 import getProducts from "./getProducts";
+import getCart from "./getCart";
 
 const safeZodParse = (
   data: unknown,
@@ -21,4 +22,11 @@ const safeZodParse = (
   }
 };
 
-export { getCollection, getCollections, getProduct, getProducts, safeZodParse };
+export {
+  getCollection,
+  getCollections,
+  getProduct,
+  getProducts,
+  safeZodParse,
+  getCart,
+};

--- a/src/api/updateCart.ts
+++ b/src/api/updateCart.ts
@@ -1,0 +1,19 @@
+"use server";
+import { safeZodParse } from "@/api";
+import client from "@/api/client";
+import { Carts, cartSchema } from "@/types/cart";
+import { cookies } from "next/headers";
+
+async function updateCart(changedData): Promise<Carts> {
+  const cookiesList = cookies();
+  const cartToken = cookiesList.get("cartToken")?.value;
+
+  const { body } = await client(`carts/${cartToken}`, false, {
+    method: "PATCH",
+    body: changedData,
+  });
+
+  return safeZodParse(body, cartSchema);
+}
+
+export default updateCart;

--- a/src/app/[affiliateSlug]/cart/page.tsx
+++ b/src/app/[affiliateSlug]/cart/page.tsx
@@ -1,3 +1,5 @@
+import { getCart } from "@/api";
+import updateCart from "@/api/updateCart";
 import Button from "@/components/Button";
 import Input from "@/components/Input";
 import LinkButton from "@/components/LinkButton";
@@ -8,101 +10,99 @@ type PageProps = {
   params: Record<string, any>;
 };
 
-const Page = ({ params }: PageProps) => {
+const Page = async ({ params }: PageProps) => {
   const { affiliateSlug } = params;
+  const { cart_items } = await getCart();
+
+  const getSubtotal = () => {
+    let subtotal = 0;
+    cart_items?.map((item) => {
+      subtotal += Number(item.price);
+    });
+    return subtotal.toFixed(2);
+  };
+
+  const updateQuantity = async (id: number, quantity: number) => {
+    try {
+      const updateItem = {
+        cart_items: { id, quantity },
+      };
+      const res = await updateCart(updateItem);
+      console.log(res);
+    } catch (error) {
+      console.error("Failed to update cart item", error);
+    }
+  };
 
   return (
-    <div className="px-20 py-28 flex flex-col gap-y-20">
-      <div className="inline-flex justify-between w-full">
-        <div className="text-5xl font-bold">Your Cart (1)</div>
+    <div className="container mx-auto p-8 md:px-10 md:py-16 lg:px-20 lg:py-28 flex flex-col gap-8 md:gap-y-20">
+      <div className="inline-flex justify-between items-center">
+        <div className="text-2xl md:text-5xl font-bold">
+          Your Cart ({cart_items?.length})
+        </div>
         <LinkButton className="mt-4" href={`/${affiliateSlug}/shop`}>
           Keep Shopping
         </LinkButton>
       </div>
-      <div className="flex flex-col">
-        <div className="inline-flex pb-4 px-4 border-b border-black">
-          <div className="flex-grow-[4]">Product</div>
-          <div className="flex-grow">Quantity</div>
-          <div className="flex-shrink text-end">Total</div>
-        </div>
-        <div className="inline-flex py-4 px-4 border-b border-black">
-          <div className="flex-grow-[4] inline-flex">
-            <img
-              src={`https://placehold.co/${145}x${128}/2F4F4F/black@3x.png`}
-              alt="placeholder image"
-              height={128}
-              width={145}
-            />
-            <div className="flex flex-col ml-4 pt-8 gap-y-1">
-              <div className="font-semibold">Product Name</div>
-              <div className="text-sm">Variant</div>
-            </div>
-          </div>
-          <div className="flex-grow inline-flex justify-end">
-            <div className="inline-flex gap-2 pt-10 mx-10">
-              <Button
-                variant="transparent-dark"
-                className="pl-4 pt-1.5 w-10 h-10"
-              >
-                -
-              </Button>
-              <Input
-                className="w-24 text-center h-10"
-                type="number"
-                defaultValue={1}
-              />
-              <Button
-                variant="transparent-dark"
-                className="pl-4 pt-1.5 h-10 w-10"
-              >
-                +
-              </Button>
-              <FontAwesomeIcon className="ml-2 pt-2.5" icon={faTrash} />
-            </div>
-          </div>
-          <div className="flex-shrink text-end pt-12">$30.00 (USD)</div>
-        </div>
-        <div className="inline-flex py-4 px-4 border-b border-black">
-          <div className="flex-grow-[4] inline-flex">
-            <img
-              src={`https://placehold.co/${145}x${128}/2F4F4F/black@3x.png`}
-              alt="placeholder image"
-              height={128}
-              width={145}
-            />
-            <div className="flex flex-col ml-4 pt-8 gap-y-1">
-              <div className="font-semibold">Product Name</div>
-              <div className="text-sm">Variant</div>
-            </div>
-          </div>
-          <div className="flex-grow inline-flex justify-end">
-            <div className="inline-flex gap-2 pt-10 mx-10">
-              <Button
-                variant="transparent-dark"
-                className="pl-4 pt-1.5 w-10 h-10"
-              >
-                -
-              </Button>
-              <Input
-                className="w-24 text-center h-10"
-                type="number"
-                defaultValue={1}
-              />
-              <Button
-                variant="transparent-dark"
-                className="pl-4 pt-1.5 h-10 w-10"
-              >
-                +
-              </Button>
-              <FontAwesomeIcon className="ml-2 pt-2.5" icon={faTrash} />
-            </div>
-          </div>
-          <div className="flex-shrink text-end pt-12">$30.00 (USD)</div>
-        </div>
+
+      <div className="overflow-auto">
+        <table className="w-full">
+          <thead className="border-b border-black ">
+            <tr>
+              <td className="px-4 pb-4 min-w-96">Product</td>
+              <td className="pr-36 pl-4 pb-4 text-end">Quantity</td>
+              <td className="px-4 pb-4 text-right">Total</td>
+            </tr>
+          </thead>
+          <tbody>
+            {cart_items?.map((item) => (
+              <tr key={item.id} className="py-4 px-4 border-b border-black">
+                <td className="flex py-4 px-4 min-w-96">
+                  <img
+                    src={`https://placehold.co/${145}x${128}/2F4F4F/black@3x.png`}
+                    alt="placeholder image"
+                    height={128}
+                    width={145}
+                  />
+                  <div className="flex flex-col ml-4 pt-8 gap-y-1">
+                    <div className="font-semibold">Product Name</div>
+                    <div className="text-sm">Variant</div>
+                  </div>
+                </td>
+                <td className="text-right">
+                  <div className="inline-flex gap-2">
+                    <Button
+                      variant="transparent-dark"
+                      className="pl-4 pt-1.5 w-10 h-10"
+                    >
+                      -
+                    </Button>
+                    <Input
+                      className="w-24 text-center h-10"
+                      type="number"
+                      defaultValue={item.quantity}
+                    />
+                    <Button
+                      variant="transparent-dark"
+                      className="pl-4 pt-1.5 h-10 w-10"
+                    >
+                      +
+                    </Button>
+                    <FontAwesomeIcon className="ml-2 pt-2.5" icon={faTrash} />
+                  </div>
+                </td>
+                <td className="text-right px-4">${item.price} (USD)</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
       </div>
+
       <div className="w-full flex justify-end">
         <div className="flex flex-col justify-end text-end gap-4 w-full max-w-[450px]">
-          <div className="font-bold text-2xl">Subtotal: $60.00 (USD)</div>
+          <div className="font-bold text-2xl">
+            Subtotal: ${getSubtotal()} (USD)
+          </div>
           <div>Taxes and shipping calculated at checkout</div>
           <Button className="w-full mt-2" variant="primary">
             Checkout

--- a/src/app/[affiliateSlug]/shop/[productSlug]/ProductPage.tsx
+++ b/src/app/[affiliateSlug]/shop/[productSlug]/ProductPage.tsx
@@ -33,13 +33,13 @@ const Page = ({ product }: Props) => {
   }, []);
 
   return (
-    <div className="pt-28 px-20">
+    <div className="container mx-auto px-10 py-16 md:pt-28 lg:px-20">
       <div className="pb-8">
         Shop &gt; <span className="font-semibold">{product.title}</span>
       </div>
-      <div className="flex flex-row w-full gap-24">
+      <div className="flex flex-col md:flex-row w-full gap-24">
         {!!(product.images.length || product.image_url) && (
-          <div className="w-1/2 flex flex-row-reverse">
+          <div className="w-full md:w-1/2 flex flex-row-reverse">
             <div className="h-full max-h-2/3 w-full relative">
               {(product.images[imageHoverIndex ?? imageSelectedIndex]
                 ?.image_url ||
@@ -86,13 +86,13 @@ const Page = ({ product }: Props) => {
         )}
         <div
           data-fluid-checkout-group={selectedVariant}
-          className="w-1/2 flex flex-col gap-6"
+          className="md:w-1/2 flex flex-col gap-6"
         >
           <div className="flex flex-col gap-2">
-            <h1 className="font-bold text-4xl">{product.title}</h1>
+            <h1 className="font-bold text-3xl md:text-4xl">{product.title}</h1>
             <h2 className="text-2xl font-bold">{product.display_price}</h2>
           </div>
-          <div className="inline-flex gap-2">
+          <div className="lg:inline-flex gap-2">
             <div className="inline-flex gap-1">
               <Star size={20} />
               <Star size={20} />
@@ -130,7 +130,7 @@ const Page = ({ product }: Props) => {
               </div>
             </div>
           )}
-          <div className="inline-flex w-1/2 justify-between gap-2">
+          <div className="xl:inline-flex 2xl:w-1/2 justify-start 2xl:justify-between gap-4">
             <div className="flex flex-row gap-2 items-center">
               <input
                 className="mr-1 checked:bg-gray-500 text-gray-500"

--- a/src/app/[affiliateSlug]/shop/[productSlug]/ProductPage.tsx
+++ b/src/app/[affiliateSlug]/shop/[productSlug]/ProductPage.tsx
@@ -4,7 +4,13 @@ import Input from "@/components/Input";
 import Star from "@/svgs/Star";
 import { Product } from "@/types/product";
 import cx from "classnames";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+
+declare global {
+  interface Window {
+    reAddFluidCheckoutListeners?: () => void;
+  }
+}
 type Props = {
   product: Product;
 };
@@ -12,13 +18,19 @@ type Props = {
 const Page = ({ product }: Props) => {
   const [imageHoverIndex, setImageHoverIndex] = useState<number>();
   const [imageSelectedIndex, setImageSelectedIndex] = useState(0);
-  const [selectedVariant, setSelectedVariant] = useState<number>(
+  const [selectedVariant, setSelectedVariant] = useState<number | undefined>(
     product.variants?.[0].id
   );
   const [quantity, setQuantity] = useState(1);
   const [subscribe, setSubscribe] = useState<"subscription" | "regular">(
     "regular"
   );
+
+  useEffect(() => {
+    if (window.reAddFluidCheckoutListeners) {
+      window.reAddFluidCheckoutListeners();
+    }
+  }, []);
 
   return (
     <div className="pt-28 px-20">
@@ -90,8 +102,10 @@ const Page = ({ product }: Props) => {
             </div>
             <div>(4.5 stars) • 10 reviews</div>
           </div>
-          <div dangerouslySetInnerHTML={{ __html: product.description }} />
-          {!!product.variants.length && (
+          {product.description && (
+            <div dangerouslySetInnerHTML={{ __html: product.description }} />
+          )}
+          {!!product.variants?.length && (
             <div className="flex flex-col gap-2">
               <div>Variant</div>
               <div className="flex flex-row gap-2 overflow-x-auto overflow-y-hidden">
@@ -166,6 +180,7 @@ const Page = ({ product }: Props) => {
           </div>
           <div className="flex flex-col gap-4 pb-6 ">
             <Button
+              onClick={() => console.log("I am clicked", selectedVariant)}
               data-fluid-checkout-type="variant"
               data-fluid-checkout-group-id={selectedVariant}
               data-variant={selectedVariant}

--- a/src/app/[affiliateSlug]/shop/[productSlug]/ProductPage.tsx
+++ b/src/app/[affiliateSlug]/shop/[productSlug]/ProductPage.tsx
@@ -8,7 +8,7 @@ import { useEffect, useState } from "react";
 
 declare global {
   interface Window {
-    reAddFluidCheckoutListeners?: () => void;
+    addFluidCheckoutListeners?: () => void;
   }
 }
 type Props = {
@@ -27,8 +27,8 @@ const Page = ({ product }: Props) => {
   );
 
   useEffect(() => {
-    if (window.reAddFluidCheckoutListeners) {
-      window.reAddFluidCheckoutListeners();
+    if (window.addFluidCheckoutListeners) {
+      window.addFluidCheckoutListeners();
     }
   }, []);
 

--- a/src/app/[affiliateSlug]/shop/page.tsx
+++ b/src/app/[affiliateSlug]/shop/page.tsx
@@ -14,10 +14,10 @@ const Shop = async () => {
   // the filtering and sorting are not implemented on purpose, we're just showing all of the products
   return (
     <>
-      <div className="flex flex-col gap-20 px-20 overflow-x-hidden mb-28">
+      <div className="container mx-auto flex flex-col px-10 md:gap-20 lg:px-20 overflow-x-hidden mb-28">
         <div className="text-4xl font-bold mt-10">All Products</div>
-        <div className="inline-flex justify-between w-full">
-          <div className="inline-flex gap-2">
+        <div className="sm:inline-flex justify-between w-full">
+          <div className="inline-flex gap-2 my-2">
             Filter:
             <div className="inline-flex gap-1">
               Availability
@@ -30,7 +30,7 @@ const Shop = async () => {
           </div>
           <div>Sort: Best Selling</div>
         </div>
-        <div className="flex flex-wrap gap-x-8 gap-y-20 justify-center overflow-x-visible">
+        <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-8">
           {(products || []).map((product) => (
             <Product key={product.id} product={product} />
           ))}

--- a/src/components/Product/index.tsx
+++ b/src/components/Product/index.tsx
@@ -18,8 +18,8 @@ const Product = ({ product }: { product: Product }) => {
               src={
                 product?.images[0]?.image_url ||
                 product?.image_url ||
-                product?.variants[0]?.images?.[0]?.image_url ||
-                product?.variants[0]?.image_urL ||
+                product?.variants?.[0]?.images?.[0]?.image_url ||
+                product?.variants?.[0]?.image_urL ||
                 "https://placehold.co/304x364/2F4F4F/black@3x.png"
               }
               className="object-contain h-[233px]"
@@ -34,7 +34,7 @@ const Product = ({ product }: { product: Product }) => {
             <div
               className="text-sm line-clamp-[8] overflow-ellipsis"
               dangerouslySetInnerHTML={{ __html: product.description }}
-            />
+            ></div>
           </div>
         </Link>
       </div>

--- a/src/components/Product/index.tsx
+++ b/src/components/Product/index.tsx
@@ -7,8 +7,8 @@ const Product = ({ product }: { product: Product }) => {
   const { affiliateSlug } = useParams();
 
   return (
-    <div className="snap-start">
-      <div className="w-[364px] h-full max-h-[466px]">
+    <div className="snap-start px-8 sm:px-4 py-8">
+      <div>
         <Link
           className="flex flex-col justify-between h-full"
           href={`/${affiliateSlug}/shop/${product.slug}`}
@@ -26,14 +26,14 @@ const Product = ({ product }: { product: Product }) => {
               alt={product?.title}
             />
           </div>
-          <div className="h-[233px] overflow-hidden">
-            <div className="inline-flex justify-between w-full my-4">
+          <div className="overflow-hidden">
+            <div className="sm:inline-flex justify-between w-full my-4">
               <h2 className="font-bold">{product.title}</h2>
               <p className="font-bold">{product.display_price}</p>
             </div>
             <div
               className="text-sm line-clamp-[8] overflow-ellipsis"
-              dangerouslySetInnerHTML={{ __html: product.description }}
+              dangerouslySetInnerHTML={{ __html: product.description || "" }}
             ></div>
           </div>
         </Link>

--- a/src/config/env_config.ts
+++ b/src/config/env_config.ts
@@ -3,7 +3,7 @@ const envConfigVariables: Record<
   Record<string, string>
 > = {
   development: {
-    widgetHost: "https://chat.fluid.app/static/js/chat-widget.js",
+    widgetHost: "http://localhost:3001/static/js/chat-widget-development.js",
     apiHost: "http://fluid.lvh.me:3000/",
   },
   production: {

--- a/src/config/env_config.ts
+++ b/src/config/env_config.ts
@@ -3,7 +3,7 @@ const envConfigVariables: Record<
   Record<string, string>
 > = {
   development: {
-    widgetHost: "http://localhost:3001/static/js/chat-widget-development.js",
+    widgetHost: "https://chat.fluid.app/static/js/chat-widget.js",
     apiHost: "http://fluid.lvh.me:3000/",
   },
   production: {

--- a/src/types/cart.ts
+++ b/src/types/cart.ts
@@ -1,0 +1,73 @@
+import { z } from "zod";
+
+const addressSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  address1: z.string(),
+  address2: z.string().nullable(),
+  address3: z.string().nullable(),
+  city: z.string(),
+  state: z.string(),
+  subdivision_code: z.string().nullable(),
+  postal_code: z.string(),
+  country_code: z.string(),
+});
+
+const shippingOptionSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  delivery_time: z.string(),
+  price: z.number(),
+  price_label: z.string(),
+});
+
+const paymentMethodSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  icons: z.array(z.string()),
+  description: z.string(),
+});
+
+const cartItemsSchema = z.object({
+  id: z.number(),
+  cart_id: z.number(),
+  variant_id: z.number(),
+  quantity: z.number(),
+  subscription: z.boolean(),
+  price: z.string(),
+  external: z.boolean(),
+  origin_url: z.string().nullable(),
+  cart_adjustment_id: z.number().nullable(),
+  subscription_start: z.string().nullable(),
+  tax: z.string(),
+  cv: z.number(),
+  qv: z.number(),
+});
+
+const cartSchema = z.object({
+  id: z.number(),
+  token: z.string(),
+  attributable_id: z.number().nullable(),
+  attributable_type: z.string().nullable(),
+  ship_to: z
+    .object({
+      address: addressSchema,
+    })
+    .nullable(),
+  bill_to: z
+    .object({
+      address: addressSchema,
+    })
+    .nullable(),
+  discount_code: z.string().nullable(),
+  available_shipping_options: z
+    .array(shippingOptionSchema)
+    .nullable()
+    .optional(),
+  available_payment_methods: z.array(paymentMethodSchema).nullable().optional(),
+  cart_items: z.array(cartItemsSchema).nullable(),
+  payment_method: paymentMethodSchema.nullable(),
+});
+
+export type Carts = z.infer<typeof cartSchema>;
+export { cartSchema };

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -26,7 +26,7 @@ const productSchema = z.object({
   keep_selling: z.boolean().nullable(),
   image_url: z.string(),
   images: z.array(imageSchema),
-  variants: z.array(variantSchema),
+  variants: z.array(variantSchema).nullable(),
 });
 
 export type Product = z.infer<typeof productSchema>;

--- a/src/types/variant.ts
+++ b/src/types/variant.ts
@@ -8,10 +8,10 @@ const variantSchema = z.object({
   is_master: z.boolean().nullable(),
   image_urL: z.string().nullable().optional(),
   buyable: z.boolean().nullable(),
-  allow_subscription: z.boolean(),
+  allow_subscription: z.boolean().nullable(),
   subscription_only: z.boolean().nullable(),
   shipping_included_in_price: z.boolean().nullable(),
-  variant_countries: z.record(variantCountrySchema),
+  variant_countries: z.record(variantCountrySchema).nullable(),
   images: z.array(imageSchema).nullable(),
 });
 

--- a/src/types/variantCountry.ts
+++ b/src/types/variantCountry.ts
@@ -7,9 +7,9 @@ const variantCountrySchema = z.object({
   shipping: z.string(),
   shipping_time: z.string().nullable(),
   currency_code: z.string(),
-  subscription_price: z.string(),
-  wholesale: z.string(),
-  wholesale_subscription_price: z.string(),
+  subscription_price: z.string().nullable(),
+  wholesale: z.string().nullable(),
+  wholesale_subscription_price: z.string().nullable(),
   cost_of_goods_sold: z.string(),
   compare_price: z.string().nullable(),
 });


### PR DESCRIPTION
Since, next uses SPA and js re-initialization doesn't happen until the page is reloaded, currently the `Add to Cart ` and `Buy Now` button click events aren't registered on widget. 
Made the events that would be taken from document to be a function on window on following chat related PR and re-called it again on the products such that each time the js would be re-initialized to listen to the click events. 
https://github.com/fluid-commerce/fluid-chat/pull/629

Also fixed the validations error for undefined/null values
